### PR TITLE
Prepare for the first release with Scala 3 support, update build+deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,27 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 3.3.0
-          - 2.13.11
-          - 2.12.18
+          - 3.3.5
+          - 2.13.16
+          - 2.12.20
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@v6
 
-      - name: scala
-        uses: olafurpg/setup-scala@v10
+      - name: setup Java 17
+        uses: actions/setup-java@v4
         with:
-          java-version: openjdk@1.11
+          java-version: '17'
+          distribution: 'oracle'
+          cache: 'sbt'
+
+      - name: setup SBT
+        uses: sbt/setup-sbt@v1
+
+      - name: check code
+        run: sbt clean check
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} clean coverage test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
-name: Publish new Release
+name: Publish Release
 
 on:
-  release:
-    types: [published]
-    branches: [master]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v3
     secrets: inherit

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import Dependencies._
+import Dependencies.*
 
 name := "sstream"
 
@@ -14,9 +14,11 @@ organizationHomepage := Some(url("https://evolution.com"))
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("3.3.0", "2.13.11", "2.12.18")
+crossScalaVersions := Seq("3.3.5", "2.13.16", "2.12.20")
 
 publishTo := Some(Resolver.evolutionReleases)
+
+versionPolicyIntention := Compatibility.BinaryCompatible
 
 libraryDependencies ++= Seq(
   Cats.core,
@@ -28,21 +30,24 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= {
   if (scalaVersion.value.startsWith("3")) Nil
-  else List(compilerPlugin(`kind-projector` cross CrossVersion.full))
+  else Seq(compilerPlugin(`kind-projector` cross CrossVersion.full))
 }
 
 ThisBuild / scalacOptions ++= {
-  if (scalaVersion.value.startsWith("3")) Seq("-Ykind-projector:underscores")
-  else Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
+  if (scalaVersion.value.startsWith("3")) Seq(
+    "-Ykind-projector:underscores",
+  ) else if (scalaVersion.value.startsWith("2.12")) Seq(
+    "-Xsource:3",
+    "-P:kind-projector:underscore-placeholders",
+  ) else Seq( // 2.13.x
+    "-Xsource:3-cross",
+    "-P:kind-projector:underscore-placeholders",
+  )
 }
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
-releaseCrossBuild := true
-
 scalacOptsFailOnWarn := Some(false)
 
-//addCommandAlias("check", "all versionPolicyCheck Compile/doc")
-addCommandAlias("check", "show version")
+addCommandAlias("check", "+all versionPolicyCheck Compile/doc")
 addCommandAlias("build", "+all compile test")
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,13 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
-  val scalatest              = "org.scalatest"              %% "scalatest"                 % "3.2.16"
-  val discipline             = "org.typelevel"              %% "discipline-scalatest"      % "2.2.0"
-  val `kind-projector`       = "org.typelevel"               % "kind-projector"            % "0.13.2"
+  val scalatest              = "org.scalatest"              %% "scalatest"                 % "3.2.19"
+  val discipline             = "org.typelevel"              %% "discipline-scalatest"      % "2.3.0"
+  val `kind-projector`       = "org.typelevel"               % "kind-projector"            % "0.13.3"
 
   object Cats {
-    private val version       = "2.7.0"
-    private val effectVersion = "3.4.11"
+    private val version       = "2.13.0"
+    private val effectVersion = "3.5.7" // do not update to 3.6.x until this fixed: https://github.com/typelevel/cats-effect/issues/4328
     val core   = "org.typelevel" %% "cats-core"   % version
     val laws   = "org.typelevel" %% "cats-laws"   % version
     val effect = "org.typelevel" %% "cats-effect" % effectVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.10.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,6 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.11")
-
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
-
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0")

--- a/src/main/scala/com/evolutiongaming/sstream/FoldWhile.scala
+++ b/src/main/scala/com/evolutiongaming/sstream/FoldWhile.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.sstream
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Foldable, Monad}
 
 trait FoldWhile[F[_]] {

--- a/src/main/scala/com/evolutiongaming/sstream/Stream.scala
+++ b/src/main/scala/com/evolutiongaming/sstream/Stream.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.sstream
 
 import cats.effect.{MonadCancel, Resource, Sync}
 import cats.kernel.Monoid
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Applicative, ApplicativeError, FlatMap, Functor, Monad, StackSafeMonad, ~>}
 
 import scala.util.{Left, Right}
@@ -248,9 +248,9 @@ object Stream { self =>
 
     final case class Take[+A] private[Cmd](value: A) extends Cmd[A]
 
-    final case object Skip extends Cmd[Nothing]
+    case object Skip extends Cmd[Nothing]
 
-    final case object Stop extends Cmd[Nothing]
+    case object Stop extends Cmd[Nothing]
   }
 
 

--- a/src/test/scala/com/evolutiongaming/sstream/IOSuite.scala
+++ b/src/test/scala/com/evolutiongaming/sstream/IOSuite.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.IORuntime
 import org.scalatest.Succeeded
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object IOSuite {
   val Timeout: FiniteDuration = 5.seconds

--- a/src/test/scala/com/evolutiongaming/sstream/StreamLawSpec.scala
+++ b/src/test/scala/com/evolutiongaming/sstream/StreamLawSpec.scala
@@ -1,4 +1,5 @@
 package com.evolutiongaming.sstream
+
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.MonadTests
 import cats.{Eq, Eval}

--- a/src/test/scala/com/evolutiongaming/sstream/StreamSpec.scala
+++ b/src/test/scala/com/evolutiongaming/sstream/StreamSpec.scala
@@ -4,7 +4,7 @@ import cats.data.IndexedStateT
 import cats.effect.kernel.{CancelScope, Poll}
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, MonadCancel, Resource}
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Id, MonadError, ~>}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.0.3-SNAPSHOT"


### PR DESCRIPTION
- CI build JDK version updated from 11 to 17
- updated dependencies, sbt and plugins
- switched to sbt-dynver plugin like in other evo OSS projects
- added sbt-version-policy for bincompat checks
- updated CI and release github actions